### PR TITLE
Fix for TypeError: node is undefined

### DIFF
--- a/shared/js/html5Forms.js
+++ b/shared/js/html5Forms.js
@@ -231,7 +231,7 @@ var html5Forms = new function () {
 					setNodeClasses(node, true);
 				}
 				
-				if (i==0 && node.type=="submit") {
+				if (i==0 && typeof node !== "undefined" && node.type=="submit") {
 					EventHelpers.addEvent(node, 'click', submitClickEvent);
 				}
 			}


### PR DESCRIPTION
When a page includes html5forms but does not have any
input/select/textarea elements, node is undefined.

I didn't look too much into the code, so there's probably a better way
of doing this.